### PR TITLE
Resolve compiler warnings

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,30 +1,8 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+#
+# This configuration file is loaded before any dependency and
+# is restricted to this project.
 
-# This configuration is loaded before any dependency and is restricted
-# to this project. If another project depends on this project, this
-# file won't be loaded nor affect the parent project. For this reason,
-# if you want to provide default values for your application for
-# 3rd-party users, it should be done in your "mix.exs" file.
-
-# You can configure your application as:
-#
-#     config :ex_crc, key: :value
-#
-# and access this configuration in your application as:
-#
-#     Application.get_env(:ex_crc, :key)
-#
-# You can also configure a 3rd-party app:
-#
-#     config :logger, level: :info
-#
-
-# It is also possible to import configuration files, relative to this
-# directory. For example, you can emulate configuration per environment
-# by uncommenting the line below and defining dev.exs, test.exs and such.
-# Configuration from the imported file will override the ones defined
-# here (which is why it is important to import them last).
-#
-#     import_config "#{Mix.env}.exs"
+# General application configuration
+import Config

--- a/lib/ex_crc.ex
+++ b/lib/ex_crc.ex
@@ -2,7 +2,7 @@ defmodule ExCRC do
   @moduledoc """
     Calculate CRC checksums
   """
-  use Bitwise
+  import Bitwise
 
   # poly=0x1021, start=0xffff, check=0x29b1
   @doc """
@@ -11,7 +11,7 @@ defmodule ExCRC do
   @spec crc16ccitt(value :: binary) :: non_neg_integer
   def crc16ccitt(value) do
     import ExCRC.Tables, only: [ccitt_table: 0]
-    calc_ccitt(:binary.bin_to_list(value), 0xffff, ccitt_table())
+    calc_ccitt(:binary.bin_to_list(value), 0xFFFF, ccitt_table())
   end
 
   # poly=0x1021, start=0x0000, check=0x2189, refin=yes, refout=yes
@@ -37,22 +37,24 @@ defmodule ExCRC do
   # Calculate CRC using ccitt table
   @spec calc_ccitt([byte], non_neg_integer, table :: map) :: non_neg_integer
   defp calc_ccitt([x | rem], crc, table) do
-    key = ((crc >>> 8) ^^^ x) &&& 0xff
-    crc = (crc <<< 8) ^^^ Map.get(table, key)
-    calc_ccitt(rem, crc &&& 0xffff, table)
+    key = Bitwise.bxor(crc >>> 8, x) &&& 0xFF
+    crc = Bitwise.bxor(crc <<< 8, Map.get(table, key))
+    calc_ccitt(rem, crc &&& 0xFFFF, table)
   end
+
   defp calc_ccitt([], crc, _), do: crc
 
   # Calculate CRC using kermit table
   @spec calc_kermit([byte], non_neg_integer, table :: map) :: non_neg_integer
   defp calc_kermit([x | rem], crc, table) do
-    key = (crc ^^^ x) &&& 0xff
-    crc = (crc >>> 8) ^^^ Map.get(table, key)
-    calc_kermit(rem, crc &&& 0xffff, table)
+    key = Bitwise.bxor(crc, x) &&& 0xFF
+    crc = Bitwise.bxor(crc >>> 8, Map.get(table, key))
+    calc_kermit(rem, crc &&& 0xFFFF, table)
   end
+
   defp calc_kermit([], crc, _) do
-    low_byte = (crc &&& 0xff00) >>> 8
-    high_byte = (crc &&& 0x00ff) <<< 8
+    low_byte = (crc &&& 0xFF00) >>> 8
+    high_byte = (crc &&& 0x00FF) <<< 8
     low_byte ||| high_byte
   end
 end

--- a/lib/generator.ex
+++ b/lib/generator.ex
@@ -3,7 +3,7 @@ defmodule ExCRC.Generator do
     Functions used to generate the static tables included by this library
   """
 
-  use Bitwise
+  import Bitwise
 
   #
   # Provide `print_crc_table/2` with a map and it will print the
@@ -45,9 +45,9 @@ defmodule ExCRC.Generator do
   # Compute a entry
   defp ccitt_entry(_, crc, 8, _), do: crc
   defp ccitt_entry(c, crc, bc, polynom) do
-    case (crc ^^^ c) &&& 0x8000 do
+    case Bitwise.bxor(crc, c) &&& 0x8000 do
       0 -> ccitt_entry(c <<< 1, crc <<< 1, bc + 1, polynom)
-      _ -> ccitt_entry(c <<< 1, (crc <<< 1) ^^^ polynom, bc + 1, polynom)
+      _ -> ccitt_entry(c <<< 1, Bitwise.bxor((crc <<< 1), polynom), bc + 1, polynom)
     end
   end
 
@@ -63,9 +63,9 @@ defmodule ExCRC.Generator do
   # Compute a entry
   defp kermit_entry(_, crc, 8, _), do: crc
   defp kermit_entry(c, crc, bc, polynom) do
-    case (crc ^^^ c) &&& 1 do
+    case Bitwise.bxor(crc, c) &&& 1 do
       0 -> kermit_entry(c >>> 1, crc >>> 1, bc + 1, polynom)
-      _ -> kermit_entry(c >>> 1, (crc >>> 1) ^^^ polynom, bc + 1, polynom)
+      _ -> kermit_entry(c >>> 1, Bitwise.bxor((crc >>> 1), polynom), bc + 1, polynom)
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule ExCRC.Mixfile do
       description: description(),
       package: package(),
       docs: [extras: ["README.md"]],
-      aliases: ["docs": ["docs", &copy_images/1]],
+      aliases: [docs: ["docs", &copy_images/1]],
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
       elixirc_paths: elixirc_paths(Mix.env),


### PR DESCRIPTION
This PR does not add any additional functionality but it does resolve compiler warnings in the current version of Elixir (1.14).

The main impetus was due to the following warning: `warning: ^^^ is deprecated. It is typically used as xor but it has the wrong precedence, use Bitwise.bxor/2 instead`.

However the following warnings were also resolved:

`warning: use Bitwise is deprecated. import Bitwise instead`

`warning: found quoted keyword "docs" but the quotes are not required. Note that keywords are always atoms, even when quoted. Similar to atoms, keywords made exclusively of ASCII letters, numbers, and underscores and not beginning with a number do not require quotes`

`warning: use Mix.Config is deprecated. Use the Config module instead`